### PR TITLE
Improve error reporting in install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Este repositorio contiene un script para instalar **Odoo 18 Community Edition** 
    ```
    El proceso instalará todas las dependencias, creará el usuario del sistema `odoo18` y dejará Odoo escuchando en [http://127.0.0.1:8069](http://127.0.0.1:8069).
 
+- Si el script se detiene por un error, se mostrará en pantalla el comando y la línea que lo provocaron, para que puedas corregirlo antes de volver a ejecutarlo.
 ## Ejemplo para usuarios novatos
 
 1. Crea una máquina virtual en **VirtualBox** con Ubuntu 24.04.2 LTS (puedes asignar 2 GB de RAM y 2 núcleos).

--- a/install_odoo18.sh
+++ b/install_odoo18.sh
@@ -3,7 +3,8 @@
 # Odoo 18 Community Edition Installation Script
 # Author: Aaron Ballesteros, SofBiz Technologies – 2025
 
-set -e
+set -Ee
+trap 'exit_code=$?; echo "El script se detuvo en la línea ${BASH_LINENO[0]} ejecutando: ${BASH_COMMAND}. Código de salida: ${exit_code}" >&2' ERR
 
 if [ $(id -u) -ne 0 ]; then
     echo "Este script debe ejecutarse como root o con sudo."


### PR DESCRIPTION
## Summary
- show line and command when script exits due to an error
- mention this behaviour in the README

## Testing
- `bash -n install_odoo18.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855d3b389b88331af4138d61500a57c