### PR TITLE
Fix wkhtmltopdf download

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Este repositorio contiene un script para instalar **Odoo 18 Community Edition** 
    sudo ./install_odoo18.sh
    ```
    El proceso instalará todas las dependencias, creará el usuario del sistema `odoo18` y dejará Odoo escuchando en [http://127.0.0.1:8069](http://127.0.0.1:8069).
+   - Si la descarga de **wkhtmltopdf** desde GitHub falla, el script intentará instalarlo automáticamente desde los repositorios de Ubuntu.
 
 - Si el script se detiene por un error, se mostrará en pantalla el comando y la línea que lo provocaron, para que puedas corregirlo antes de volver a ejecutarlo.
 ## Ejemplo para usuarios novatos

--- a/install_odoo18.sh
+++ b/install_odoo18.sh
@@ -60,9 +60,13 @@ apt install -y git wget python3-pip python3-venv build-essential \
 # Instalar wkhtmltopdf
 echo "Instalando wkhtmltopdf..."
 WKHTML_DEB=wkhtmltox_0.12.6-1.jammy_amd64.deb
-wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.6/$WKHTML_DEB
-apt install -y ./$WKHTML_DEB
-rm -f $WKHTML_DEB
+if wget -q https://github.com/wkhtmltopdf/wkhtmltopdf/releases/download/0.12.6/$WKHTML_DEB; then
+    apt install -y ./$WKHTML_DEB
+    rm -f $WKHTML_DEB
+else
+    echo "Descarga directa fall\u00f3, instalando wkhtmltopdf desde apt..."
+    apt install -y wkhtmltopdf
+fi
 
 # Descargar código de Odoo
 echo "Clonando código de Odoo 18 Community Edition..."


### PR DESCRIPTION
## Summary
- handle download failure of wkhtmltopdf in script
- document automatic fallback installation in README

## Testing
- `bash -n install_odoo18.sh`

------
https://chatgpt.com/codex/tasks/task_e_6855dc3e45dc8331bde4f07887d423d9